### PR TITLE
fix(foxglove-bridge): use default the default value for port and IP

### DIFF
--- a/snap/local/configuration/foxglove-bridge.yaml
+++ b/snap/local/configuration/foxglove-bridge.yaml
@@ -1,3 +1,3 @@
-port: 54321 # websocket port to broadcast ROS data
-address: device-vpn-hostname # websocket address to broadcast ROS data
+port: 8765 # websocket port to broadcast ROS data
+address: 0.0.0.0 # websocket address to broadcast ROS data
 topic-whitelist: "['/camera/color/image_raw', '/tf', '/scan_filtered', '/rosout']" # topic regex to include topics to the broadcast


### PR DESCRIPTION
Use the default port of foxglove bridge.
Expose the foxglove bridge on all interfaces by default