### PR TITLE
Feat/grafana tls config

### DIFF
--- a/snap/local/configuration/grafana-agent.river
+++ b/snap/local/configuration/grafana-agent.river
@@ -28,6 +28,10 @@ prometheus.remote_write "default" {
     }
 	endpoint {
 		url = "http://rob-cos-ip-placeholder/model-name-placeholder" + "-prometheus-0/api/v1/write"
+		tls_config {
+            ca_file             = "/etc/ssl/certs/ca-certificates.crt"
+            insecure_skip_verify = true
+        }
 	}
 }
 
@@ -40,5 +44,9 @@ loki.source.journal "read" {
 loki.write "endpoint" {
 	endpoint {
 		url = "http://rob-cos-ip-placeholder/model-name-placeholder" + "-loki-0/loki/api/v1/push"
+		tls_config {
+            ca_file             = "/etc/ssl/certs/ca-certificates.crt"
+            insecure_skip_verify = true
+        }
 	}
 }

--- a/snap/local/configuration/grafana-agent.river
+++ b/snap/local/configuration/grafana-agent.river
@@ -30,7 +30,6 @@ prometheus.remote_write "default" {
 		url = "http://rob-cos-ip-placeholder/model-name-placeholder" + "-prometheus-0/api/v1/write"
 		tls_config {
             ca_file             = "/etc/ssl/certs/ca-certificates.crt"
-            insecure_skip_verify = true
         }
 	}
 }
@@ -46,7 +45,6 @@ loki.write "endpoint" {
 		url = "http://rob-cos-ip-placeholder/model-name-placeholder" + "-loki-0/loki/api/v1/push"
 		tls_config {
             ca_file             = "/etc/ssl/certs/ca-certificates.crt"
-            insecure_skip_verify = true
         }
 	}
 }


### PR DESCRIPTION
Update grafana river configuration to use system level cert file if TLS is enabled.

To merge after https://github.com/canonical/rob-cos-demo-configuration/pull/24.