### PR TITLE
Fix advanced snap workflow

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   workflow_call:
    inputs:
-      branch:
+      branch-name:
         required: false
         type: string
         default: ''


### PR DESCRIPTION
Fix workflow to make sure correct branch-name is picked by git-ref when building the snap.