### PR TITLE
Use correct snap workflow version in monthly

### DIFF
--- a/.github/workflows/monthly.yaml
+++ b/.github/workflows/monthly.yaml
@@ -6,10 +6,10 @@ on:
 
 jobs:
   basic:
-    uses: canonical/rob-cos-demo-configuration/.github/workflows/snap.yaml@main
+    uses: canonical/rob-cos-demo-configuration/.github/workflows/snap.yaml@basic
     with:
       branch-name: "basic"
   advanced:
-    uses: canonical/rob-cos-demo-configuration/.github/workflows/snap.yaml@main
+    uses: canonical/rob-cos-demo-configuration/.github/workflows/snap.yaml@advanced
     with:
       branch-name: "advanced"


### PR DESCRIPTION
Since the monthly is running basic and advanced it should be using the basic and advanced version of the snap.yaml file to work correctly.