### PR TITLE
Add confdb, with comprehensive logging to configure hook 

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -25,11 +25,6 @@ defaults_file = os.path.join(
     "etc/configuration/defaults/device.yaml"
 )
 
-# Check if defaults file exists
-if not os.path.exists(defaults_file):
-    logger.error(f"Defaults file not found: {defaults_file}")
-    sys.exit(1)
-
 try:
     # Get snap configuration values first
     def get_snap_config(key):
@@ -78,7 +73,7 @@ try:
     
     # Write to confdb
     result = subprocess.run(
-        ["snapctl", "set", "--view", ":cos-registration-agent-observe", f"data={config_data}"],
+        ["snapctl", "set", "--view", ":cos-registration-agent-control-configuration", f"data={config_data}"],
         capture_output=True,
         text=True
     )

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -31,11 +31,7 @@ if not os.path.exists(defaults_file):
     sys.exit(1)
 
 try:
-    # Read default YAML file
-    with open(defaults_file, 'r') as f:
-        config_data = f.read()
-    
-    # Get snap configuration values
+    # Get snap configuration values first
     def get_snap_config(key):
         """Get snap configuration value."""
         try:
@@ -51,18 +47,34 @@ try:
             pass
         return None
     
-    # Replace placeholders with snap config values
     rob_cos_ip = get_snap_config("rob-cos-ip")
-    if rob_cos_ip:
-        config_data = config_data.replace("rob-cos-ip-placeholder", rob_cos_ip)
-    
     model_name = get_snap_config("model-name")
-    if model_name:
-        config_data = config_data.replace("model-name-placeholder", model_name)
-    
     robot_uid = get_snap_config("robot-uid")
-    if robot_uid:
-        config_data = config_data.replace("robot-uid-placeholder", robot_uid)
+    
+    # Validate that all required configuration values are set
+    missing_values = []
+    if not rob_cos_ip:
+        missing_values.append("rob-cos-ip")
+    if not model_name:
+        missing_values.append("model-name")
+    if not robot_uid:
+        missing_values.append("robot-uid")
+    
+    if missing_values:
+        logger.info(f"Configuration incomplete. Missing values: {', '.join(missing_values)}")
+        logger.info("Skipping confdb and file updates until all values are set")
+        sys.exit(0)
+    
+    logger.info("All configuration values present, updating confdb and files")
+    
+    # Read default YAML file
+    with open(defaults_file, 'r') as f:
+        config_data = f.read()
+    
+    # Replace placeholders with snap config values
+    config_data = config_data.replace("rob-cos-ip-placeholder", rob_cos_ip)
+    config_data = config_data.replace("model-name-placeholder", model_name)
+    config_data = config_data.replace("robot-uid-placeholder", robot_uid)
     
     # Write to confdb
     result = subprocess.run(
@@ -75,6 +87,22 @@ try:
         logger.warning(f"Failed to write to confdb: {result.stderr}")
     else:
         logger.info("Configuration updated in confdb")
+    
+    # Update file-based configuration for content slot consumers
+    search_replace_script = os.path.join(
+        os.environ.get("SNAP", ""),
+        "usr/bin/search_and_replace.sh"
+    )
+    
+    result = subprocess.run(
+        [search_replace_script],
+        capture_output=True,
+        text=True
+    )
+    if result.returncode != 0:
+        logger.warning(f"Failed to update configuration files: {result.stderr}")
+    else:
+        logger.info("Configuration files updated")
 
 except Exception as e:
     logger.error(f"Error updating confdb: {e}")

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,83 @@
-#!/bin/sh -e
+#!/usr/bin/env python3
 
-bash $SNAP/usr/bin/search_and_replace.sh
+import os
+import subprocess
+import sys
+import logging
+import logging.handlers
+
+# Setup logging to journald only
+logger = logging.getLogger("configure-hook")
+logger.setLevel(logging.INFO)
+
+# Journald/syslog handler
+try:
+    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+    syslog_formatter = logging.Formatter('rob-cos-demo-configuration.configure: %(message)s')
+    syslog_handler.setFormatter(syslog_formatter)
+    logger.addHandler(syslog_handler)
+except Exception:
+    pass  # Silently fail if syslog unavailable
+
+# Path to the default configuration file
+defaults_file = os.path.join(
+    os.environ.get("SNAP", ""),
+    "etc/configuration/defaults/device.yaml"
+)
+
+# Check if defaults file exists
+if not os.path.exists(defaults_file):
+    logger.error(f"Defaults file not found: {defaults_file}")
+    sys.exit(1)
+
+try:
+    # Read default YAML file
+    with open(defaults_file, 'r') as f:
+        config_data = f.read()
+    
+    # Get snap configuration values
+    def get_snap_config(key):
+        """Get snap configuration value."""
+        try:
+            result = subprocess.run(
+                ["snapctl", "get", key],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except Exception:
+            pass
+        return None
+    
+    # Replace placeholders with snap config values
+    rob_cos_ip = get_snap_config("rob-cos-ip")
+    if rob_cos_ip:
+        config_data = config_data.replace("rob-cos-ip-placeholder", rob_cos_ip)
+    
+    model_name = get_snap_config("model-name")
+    if model_name:
+        config_data = config_data.replace("model-name-placeholder", model_name)
+    
+    robot_uid = get_snap_config("robot-uid")
+    if robot_uid:
+        config_data = config_data.replace("robot-uid-placeholder", robot_uid)
+    
+    # Write to confdb
+    result = subprocess.run(
+        ["snapctl", "set", "--view", ":cos-registration-agent-observe", f"data={config_data}"],
+        capture_output=True,
+        text=True
+    )
+    
+    if result.returncode != 0:
+        logger.warning(f"Failed to write to confdb: {result.stderr}")
+    else:
+        logger.info("Configuration updated in confdb")
+
+except Exception as e:
+    logger.error(f"Error updating confdb: {e}")
+
+# Always exit successfully
+sys.exit(0)

--- a/snap/hooks/connect-plug-cos-registration-agent-control-configuration
+++ b/snap/hooks/connect-plug-cos-registration-agent-control-configuration
@@ -21,15 +21,10 @@ defaults_file = os.path.join(
     "etc/configuration/defaults/device.yaml"
 )
 
-# Check if defaults file exists
-if not os.path.exists(defaults_file):
-    logger.warning(f"Defaults file not found: {defaults_file}")
-    sys.exit(0)
-
 try:
     # Check if confdb already has data
     check_result = subprocess.run(
-        ["snapctl", "get", "--view", ":cos-registration-agent-observe", "data"],
+        ["snapctl", "get", "--view", ":cos-registration-agent-control-configuration", "data"],
         capture_output=True,
         text=True
     )
@@ -39,15 +34,41 @@ try:
         logger.info("Confdb already initialized, skipping default value write")
         sys.exit(0)
     
-    logger.info("Confdb is empty, initializing with default configuration")
+    # Check if snap configuration values are already set
+    def get_snap_config(key):
+        """Get snap configuration value."""
+        try:
+            result = subprocess.run(
+                ["snapctl", "get", key],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                return result.stdout.strip()
+        except Exception:
+            pass
+        return None
+    
+    rob_cos_ip = get_snap_config("rob-cos-ip")
+    model_name = get_snap_config("model-name")
+    robot_uid = get_snap_config("robot-uid")
+    
+    # Check if any configuration values are already set
+    if rob_cos_ip or model_name or robot_uid:
+        logger.info("Snap configuration values are set, skipping placeholder initialization")
+        logger.info("Configure hook will write values to confdb when all are set")
+        sys.exit(0)
+    
+    logger.info("Confdb is empty and snap config not set, initializing with placeholders")
     
     # Read default YAML file
     with open(defaults_file, 'r') as f:
         default_config = f.read()
     
-    # Write to confdb only if it was empty
+    # Write to confdb only if it was empty and no config is set
     result = subprocess.run(
-        ["snapctl", "set", "--view", ":cos-registration-agent-observe", f"data={default_config}"],
+        ["snapctl", "set", "--view", ":cos-registration-agent-control-configuration", f"data={default_config}"],
         capture_output=True,
         text=True
     )

--- a/snap/hooks/connect-plug-cos-registration-agent-control-configuration
+++ b/snap/hooks/connect-plug-cos-registration-agent-control-configuration
@@ -1,85 +1,14 @@
-#!/usr/bin/env python3
+#!/bin/sh -e
 
-import os
-import subprocess
-import sys
-import logging.handlers
+# The connect hook cannot access confdb (it would cause a deadlock).
+# Instead, we start a service that will handle confdb initialization.
+# The service will:
+# - If snap config values (rob-cos-ip, model-name, robot-uid) are NOT all set → disable itself
+# - If snap config values ARE all set → read defaults, replace placeholders with real values,
+#   write to confdb, retry every 30 seconds if write fails, disable itself once successful
 
-# Setup logging to journald
-logger = logging.getLogger()
-try:
-    handler = logging.handlers.SysLogHandler(address='/dev/log')
-    handler.setFormatter(logging.Formatter('rob-cos-demo-configuration.connect-plug: %(message)s'))
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
-except Exception:
-    pass
+# Start the confdb initialization service
+# It's installed as disabled, so we need to start it explicitly
+snapctl start --enable rob-cos-demo-configuration.init-confdb
 
-# Path to the default configuration file
-defaults_file = os.path.join(
-    os.environ.get("SNAP", ""),
-    "etc/configuration/defaults/device.yaml"
-)
-
-try:
-    # Check if confdb already has data
-    check_result = subprocess.run(
-        ["snapctl", "get", "--view", ":cos-registration-agent-control-configuration", "data"],
-        capture_output=True,
-        text=True
-    )
-    
-    # If confdb already has data, don't overwrite it
-    if check_result.returncode == 0 and check_result.stdout.strip():
-        logger.info("Confdb already initialized, skipping default value write")
-        sys.exit(0)
-    
-    # Check if snap configuration values are already set
-    def get_snap_config(key):
-        """Get snap configuration value."""
-        try:
-            result = subprocess.run(
-                ["snapctl", "get", key],
-                capture_output=True,
-                text=True,
-                check=False
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
-        except Exception:
-            pass
-        return None
-    
-    rob_cos_ip = get_snap_config("rob-cos-ip")
-    model_name = get_snap_config("model-name")
-    robot_uid = get_snap_config("robot-uid")
-    
-    # Check if any configuration values are already set
-    if rob_cos_ip or model_name or robot_uid:
-        logger.info("Snap configuration values are set, skipping placeholder initialization")
-        logger.info("Configure hook will write values to confdb when all are set")
-        sys.exit(0)
-    
-    logger.info("Confdb is empty and snap config not set, initializing with placeholders")
-    
-    # Read default YAML file
-    with open(defaults_file, 'r') as f:
-        default_config = f.read()
-    
-    # Write to confdb only if it was empty and no config is set
-    result = subprocess.run(
-        ["snapctl", "set", "--view", ":cos-registration-agent-control-configuration", f"data={default_config}"],
-        capture_output=True,
-        text=True
-    )
-    
-    if result.returncode != 0:
-        logger.warning(f"Failed to write defaults to confdb: {result.stderr}")
-    else:
-        logger.info("Initialized confdb with default configuration")
-
-except Exception as e:
-    logger.error(f"Error initializing confdb: {e}")
-
-# Always exit successfully
-sys.exit(0)
+exit 0

--- a/snap/hooks/connect-plug-cos-registration-agent-observe
+++ b/snap/hooks/connect-plug-cos-registration-agent-observe
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+import logging.handlers
+
+# Setup logging to journald
+logger = logging.getLogger()
+try:
+    handler = logging.handlers.SysLogHandler(address='/dev/log')
+    handler.setFormatter(logging.Formatter('rob-cos-demo-configuration.connect-plug: %(message)s'))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+except Exception:
+    pass
+
+# Path to the default configuration file
+defaults_file = os.path.join(
+    os.environ.get("SNAP", ""),
+    "etc/configuration/defaults/device.yaml"
+)
+
+# Check if defaults file exists
+if not os.path.exists(defaults_file):
+    logger.warning(f"Defaults file not found: {defaults_file}")
+    sys.exit(0)
+
+try:
+    # Read default YAML file
+    with open(defaults_file, 'r') as f:
+        default_config = f.read()
+    
+    # Write to confdb
+    result = subprocess.run(
+        ["snapctl", "set", "--view", ":cos-registration-agent-observe", f"data={default_config}"],
+        capture_output=True,
+        text=True
+    )
+    
+    if result.returncode != 0:
+        logger.warning(f"Failed to write defaults to confdb: {result.stderr}")
+    else:
+        logger.info("Initialized confdb with default configuration")
+
+except Exception as e:
+    logger.error(f"Error initializing confdb: {e}")
+
+# Always exit successfully
+sys.exit(0)

--- a/snap/hooks/connect-plug-cos-registration-agent-observe
+++ b/snap/hooks/connect-plug-cos-registration-agent-observe
@@ -27,11 +27,25 @@ if not os.path.exists(defaults_file):
     sys.exit(0)
 
 try:
+    # Check if confdb already has data
+    check_result = subprocess.run(
+        ["snapctl", "get", "--view", ":cos-registration-agent-observe", "data"],
+        capture_output=True,
+        text=True
+    )
+    
+    # If confdb already has data, don't overwrite it
+    if check_result.returncode == 0 and check_result.stdout.strip():
+        logger.info("Confdb already initialized, skipping default value write")
+        sys.exit(0)
+    
+    logger.info("Confdb is empty, initializing with default configuration")
+    
     # Read default YAML file
     with open(defaults_file, 'r') as f:
         default_config = f.read()
     
-    # Write to confdb
+    # Write to confdb only if it was empty
     result = subprocess.run(
         ["snapctl", "set", "--view", ":cos-registration-agent-observe", f"data={default_config}"],
         capture_output=True,

--- a/snap/local/configuration/defaults/device.yaml
+++ b/snap/local/configuration/defaults/device.yaml
@@ -1,0 +1,6 @@
+url: http://rob-cos-ip-placeholder/model-name-placeholder-cos-registration-server/
+uid: robot-uid-placeholder
+device-grafana-dashboards: [linux-system, systemd-and-snaps-logs]
+device-foxglove-dashboards: [topics-and-logs, teleop]
+device-loki-alert-rule-files: [human_detected]
+device-prometheus-alert-rule-files: [low_memory]

--- a/snap/local/init_confdb_service.py
+++ b/snap/local/init_confdb_service.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+import logging.handlers
+import time
+
+# Setup logging to journald
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+try:
+    handler = logging.handlers.SysLogHandler(address='/dev/log')
+    handler.setFormatter(logging.Formatter('rob-cos-demo-configuration.init-confdb-service: %(message)s'))
+    logger.addHandler(handler)
+except Exception:
+    pass
+
+# Configuration mapping: snap config key -> placeholder name
+CONFIG_MAPPINGS = {
+    "rob-cos-ip": "rob-cos-ip-placeholder",
+    "model-name": "model-name-placeholder",
+    "robot-uid": "robot-uid-placeholder",
+}
+
+
+def get_snap_config(key):
+    """Get snap configuration value."""
+    try:
+        result = subprocess.run(
+            ["snapctl", "get", key],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def stop_service():
+    """Stop this service."""
+    try:
+        subprocess.run(
+            ["snapctl", "stop", "--disable", "rob-cos-demo-configuration.init-confdb"],
+            capture_output=True,
+            text=True
+        )
+        logger.info("Service stopped and disabled successfully")
+    except Exception as e:
+        logger.warning(f"Failed to disable service: {e}")
+
+
+def write_config_to_confdb(config_values):
+    """Write configuration with real values to confdb.
+    
+    Args:
+        config_values: Dictionary mapping config keys to their values
+    """
+    defaults_file = os.path.join(
+        os.environ.get("SNAP", ""),
+        "etc/configuration/defaults/device.yaml"
+    )
+    
+    try:
+        # Read default YAML file
+        with open(defaults_file, 'r') as f:
+            config_data = f.read()
+        
+        # Replace all placeholders with real values
+        for config_key, placeholder in CONFIG_MAPPINGS.items():
+            config_data = config_data.replace(placeholder, config_values[config_key])
+        
+        # Write to confdb
+        result = subprocess.run(
+            ["snapctl", "set", "--view", ":cos-registration-agent-control-configuration", f"data={config_data}"],
+            capture_output=True,
+            text=True
+        )
+        
+        if result.returncode != 0:
+            logger.warning(f"Failed to write configuration to confdb: {result.stderr}")
+            return False
+        else:
+            logger.info("Successfully wrote configuration to confdb")
+            return True
+    except Exception as e:
+        logger.error(f"Error writing to confdb: {e}")
+        return False
+
+
+def main():
+    """Main service loop."""
+    logger.info("Confdb initialization service started")
+    
+    # Get all snap configuration values
+    config_values = {}
+    for config_key in CONFIG_MAPPINGS.keys():
+        config_values[config_key] = get_snap_config(config_key)
+    
+    # Check if all required values are set
+    missing_values = [key for key, value in config_values.items() if not value]
+    
+    if missing_values:
+        logger.info("Configuration values not all set, disabling service")
+        status_parts = [f"{key}: {'set' if config_values[key] else 'not set'}" 
+                       for key in CONFIG_MAPPINGS.keys()]
+        logger.info(", ".join(status_parts))
+        stop_service()
+        return
+    
+    logger.info("All configuration values are set, writing to confdb")
+    
+    # Retry loop: try to write configuration to confdb
+    max_retries = 60  # Max 30 minutes (60 * 30 seconds)
+    retry_count = 0
+    
+    while retry_count < max_retries:
+        if write_config_to_confdb(config_values):
+            logger.info("Confdb write successful, disabling service")
+            stop_service()
+            return
+        
+        retry_count += 1
+        logger.warning(f"Confdb write failed, retrying in 30 seconds (attempt {retry_count}/{max_retries})")
+        time.sleep(30)
+    
+    logger.error(f"Failed to write to confdb after {max_retries} attempts, giving up")
+    stop_service()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.error(f"Unexpected error in confdb initialization service: {e}")
+        sys.exit(1)

--- a/snap/local/search_and_replace.sh
+++ b/snap/local/search_and_replace.sh
@@ -23,7 +23,6 @@ CURRENT_DEVICE_ID=$(snapctl get device-uid)
 STORED_DEVICE_ID=$(cat $SNAP_COMMON/configuration/uid)
 
 if [ "$CURRENT_DEVICE_ID" != "$STORED_DEVICE_ID" ]; then
-    echo "device_id is different updating!"
     search_and_replace $STORED_DEVICE_ID $CURRENT_DEVICE_ID
 fi
 
@@ -33,7 +32,6 @@ STORED_COS_SERVER_URL=$(cat $SNAP_COMMON/configuration/rob-cos-base-url)
 STORED_COS_SERVER_IP="$(echo "$STORED_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)"
 
 if [ "$CURRENT_COS_SERVER_URL" != "$STORED_COS_SERVER_URL" ]; then
-    echo "rob-cos-base-url is different updating!"
     search_and_replace $STORED_COS_SERVER_URL $CURRENT_COS_SERVER_URL
     search_and_replace $STORED_COS_SERVER_IP $CURRENT_COS_SERVER_IP
 fi

--- a/snap/local/search_and_replace.sh
+++ b/snap/local/search_and_replace.sh
@@ -1,37 +1,53 @@
 #!/bin/sh -e
 
-# function to search and replace keywords in
-# SNAP_COMMON's configuration files
+# Script to update configuration files in $SNAP_COMMON/configuration
+# with values from snap configuration (confdb-first architecture)
+
+# Defaults file contains placeholder definitions
+DEFAULTS_FILE="$SNAP/etc/configuration/defaults/device.yaml"
+CONFIG_DIR="$SNAP_COMMON/configuration"
+
+if [ ! -f "$DEFAULTS_FILE" ]; then
+    logger -t rob-cos-demo-configuration "ERROR: Defaults file not found: $DEFAULTS_FILE"
+    exit 1
+fi
+
+if [ ! -d "$CONFIG_DIR" ]; then
+    logger -t rob-cos-demo-configuration "ERROR: Configuration directory not found: $CONFIG_DIR"
+    exit 1
+fi
+
+# Function to replace placeholder in all config files
 search_and_replace() {
-    if [ "$#" -ne 2 ]; then
-        echo "Usage: search_and_replace <keyword> <replacement>"
-        return 1
+    local placeholder="$1"
+    local value="$2"
+    
+    if [ -z "$value" ]; then
+        return
     fi
-
-    local keyword="$1"
-    local replacement="$2"
-
-    local directory="$SNAP_COMMON/configuration"
-    local files=$(find "$directory" -type f)
-
-    for file in $files; do
-        sed -i "s#$keyword#$replacement#g" "$file"
-    done
+    
+    find "$CONFIG_DIR" -type f -exec sed -i "s#${placeholder}#${value}#g" {} \;
 }
 
-CURRENT_DEVICE_ID=$(snapctl get device-uid)
-STORED_DEVICE_ID=$(cat $SNAP_COMMON/configuration/uid)
+# Get snap configuration values
+ROB_COS_IP=$(snapctl get rob-cos-ip 2>/dev/null || echo "")
+MODEL_NAME=$(snapctl get model-name 2>/dev/null || echo "")
+ROBOT_UID=$(snapctl get robot-uid 2>/dev/null || echo "")
 
-if [ "$CURRENT_DEVICE_ID" != "$STORED_DEVICE_ID" ]; then
-    search_and_replace $STORED_DEVICE_ID $CURRENT_DEVICE_ID
+# Replace placeholders with actual values
+if [ -n "$ROB_COS_IP" ]; then
+    search_and_replace "rob-cos-ip-placeholder" "$ROB_COS_IP"
+    logger -t rob-cos-demo-configuration "Updated rob-cos-ip in configuration files"
 fi
 
-CURRENT_COS_SERVER_URL=$(snapctl get rob-cos-base-url)
-CURRENT_COS_SERVER_IP=$(echo "$CURRENT_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)
-STORED_COS_SERVER_URL=$(cat $SNAP_COMMON/configuration/rob-cos-base-url)
-STORED_COS_SERVER_IP="$(echo "$STORED_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)"
-
-if [ "$CURRENT_COS_SERVER_URL" != "$STORED_COS_SERVER_URL" ]; then
-    search_and_replace $STORED_COS_SERVER_URL $CURRENT_COS_SERVER_URL
-    search_and_replace $STORED_COS_SERVER_IP $CURRENT_COS_SERVER_IP
+if [ -n "$MODEL_NAME" ]; then
+    search_and_replace "model-name-placeholder" "$MODEL_NAME"
+    logger -t rob-cos-demo-configuration "Updated model-name in configuration files"
 fi
+
+if [ -n "$ROBOT_UID" ]; then
+    search_and_replace "robot-uid-placeholder" "$ROBOT_UID"
+    logger -t rob-cos-demo-configuration "Updated robot-uid in configuration files"
+fi
+
+logger -t rob-cos-demo-configuration "Configuration files updated successfully"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,7 @@ parts:
     source: snap/local/
     organize:
       '*.sh': usr/bin/
+      '*.py': usr/bin/
   configuration:
     plugin: dump
     source: snap/local/configuration/
@@ -56,3 +57,9 @@ apps:
 
   reset-config:
     command: usr/bin/reset_config.sh
+
+  init-confdb:
+    command: usr/bin/init_confdb_service.py
+    daemon: simple
+    install-mode: disable
+    plugs: [cos-registration-agent-control-configuration]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,18 @@ description: |
 grade: stable
 confinement: strict
 
+plugs:
+  cos-registration-agent-observe:
+    interface: confdb
+    account: VX84EGFo6txXHSNk4l55reEiaU5n7I7R
+    view: cos-registration-agent/control-configuration
+
+hooks:
+  configure:
+    plugs: [cos-registration-agent-observe]
+  connect-plug-cos-registration-agent-observe:
+    plugs: [cos-registration-agent-observe]
+
 slots:
   configuration-read:
     interface: content

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,16 +21,16 @@ grade: stable
 confinement: strict
 
 plugs:
-  cos-registration-agent-observe:
+  cos-registration-agent-control-configuration:
     interface: confdb
     account: VX84EGFo6txXHSNk4l55reEiaU5n7I7R
     view: cos-registration-agent/control-configuration
 
 hooks:
   configure:
-    plugs: [cos-registration-agent-observe]
-  connect-plug-cos-registration-agent-observe:
-    plugs: [cos-registration-agent-observe]
+    plugs: [cos-registration-agent-control-configuration]
+  connect-plug-cos-registration-agent-control-configuration:
+    plugs: [cos-registration-agent-control-configuration]
 
 slots:
   configuration-read:


### PR DESCRIPTION
- Add more logging to hook using Python logging library
- Change view from 'configuration' to 'control-configuration' for write access
- Add exception handling with full tracebacks
- Rename hooks to match cos-registration-agent naming convention