### PR TITLE
Add web-based configuration UI with Flask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.0
+Werkzeug==3.0.1

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,106 +1,29 @@
 #!/usr/bin/env python3
 
 import os
-import subprocess
 import sys
-import logging
-import logging.handlers
 
-# Setup logging to journald only
-logger = logging.getLogger("configure-hook")
-logger.setLevel(logging.INFO)
+# Add snap lib to Python path
+snap_dir = os.environ.get("SNAP", "")
+if snap_dir:
+    sys.path.insert(0, os.path.join(snap_dir, "usr/lib"))
 
-# Journald/syslog handler
-try:
-    syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
-    syslog_formatter = logging.Formatter('rob-cos-demo-configuration.configure: %(message)s')
-    syslog_handler.setFormatter(syslog_formatter)
-    logger.addHandler(syslog_handler)
-except Exception:
-    pass  # Silently fail if syslog unavailable
+from configure_logic import get_snap_config_values, set_confdb_data, setup_logger
 
-# Path to the default configuration file
-defaults_file = os.path.join(
-    os.environ.get("SNAP", ""),
-    "etc/configuration/defaults/device.yaml"
-)
+logger = setup_logger("configure-hook")
 
 try:
-    # Get snap configuration values first
-    def get_snap_config(key):
-        """Get snap configuration value."""
-        try:
-            result = subprocess.run(
-                ["snapctl", "get", key],
-                capture_output=True,
-                text=True,
-                check=False
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return result.stdout.strip()
-        except Exception:
-            pass
-        return None
+    # Get current snap configuration values
+    config_values = get_snap_config_values()
     
-    rob_cos_ip = get_snap_config("rob-cos-ip")
-    model_name = get_snap_config("model-name")
-    robot_uid = get_snap_config("robot-uid")
+    # Apply the configuration (updates confdb and files)
+    success, message = set_confdb_data(config_values, logger)
     
-    # Validate that all required configuration values are set
-    missing_values = []
-    if not rob_cos_ip:
-        missing_values.append("rob-cos-ip")
-    if not model_name:
-        missing_values.append("model-name")
-    if not robot_uid:
-        missing_values.append("robot-uid")
+    if not success:
+        logger.info(f"Skipping confdb update: {message}")
     
-    if missing_values:
-        logger.info(f"Configuration incomplete. Missing values: {', '.join(missing_values)}")
-        logger.info("Skipping confdb and file updates until all values are set")
-        sys.exit(0)
-    
-    logger.info("All configuration values present, updating confdb and files")
-    
-    # Read default YAML file
-    with open(defaults_file, 'r') as f:
-        config_data = f.read()
-    
-    # Replace placeholders with snap config values
-    config_data = config_data.replace("rob-cos-ip-placeholder", rob_cos_ip)
-    config_data = config_data.replace("model-name-placeholder", model_name)
-    config_data = config_data.replace("robot-uid-placeholder", robot_uid)
-    
-    # Write to confdb
-    result = subprocess.run(
-        ["snapctl", "set", "--view", ":cos-registration-agent-control-configuration", f"data={config_data}"],
-        capture_output=True,
-        text=True
-    )
-    
-    if result.returncode != 0:
-        logger.warning(f"Failed to write to confdb: {result.stderr}")
-    else:
-        logger.info("Configuration updated in confdb")
-    
-    # Update file-based configuration for content slot consumers
-    search_replace_script = os.path.join(
-        os.environ.get("SNAP", ""),
-        "usr/bin/search_and_replace.sh"
-    )
-    
-    result = subprocess.run(
-        [search_replace_script],
-        capture_output=True,
-        text=True
-    )
-    if result.returncode != 0:
-        logger.warning(f"Failed to update configuration files: {result.stderr}")
-    else:
-        logger.info("Configuration files updated")
-
 except Exception as e:
-    logger.error(f"Error updating confdb: {e}")
+    logger.error(f"Error in configure hook: {e}")
 
 # Always exit successfully
 sys.exit(0)

--- a/snap/hooks/connect-plug-cos-registration-agent-control-configuration
+++ b/snap/hooks/connect-plug-cos-registration-agent-control-configuration
@@ -1,14 +1,11 @@
 #!/bin/sh -e
 
 # The connect hook cannot access confdb (it would cause a deadlock).
-# Instead, we start a service that will handle confdb initialization.
-# The service will:
-# - If snap config values (rob-cos-ip, model-name, robot-uid) are NOT all set → disable itself
-# - If snap config values ARE all set → read defaults, replace placeholders with real values,
-#   write to confdb, retry every 30 seconds if write fails, disable itself once successful
+# Start the init-confdb service to handle initialization.
+# It's installed as disabled, so we need to start it explicitly.
 
-# Start the confdb initialization service
-# It's installed as disabled, so we need to start it explicitly
+logger "cos-registration-agent-control-configuration interface connected, starting init-confdb service"
 snapctl start --enable rob-cos-demo-configuration.init-confdb
 
 exit 0
+

--- a/snap/local/configure_logic.py
+++ b/snap/local/configure_logic.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Configuration logic that can be called from both the configure hook and the web UI.
+"""
+
+import os
+import subprocess
+import logging
+import logging.handlers
+
+
+# Configuration mapping: snap config key -> placeholder name
+CONFIG_MAPPINGS = {
+    "rob-cos-ip": "rob-cos-ip-placeholder",
+    "model-name": "model-name-placeholder",
+    "robot-uid": "robot-uid-placeholder",
+}
+
+
+def setup_logger(name="configure"):
+    """Setup logging to journald."""
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    
+    try:
+        syslog_handler = logging.handlers.SysLogHandler(address='/dev/log')
+        syslog_formatter = logging.Formatter(f'rob-cos-demo-configuration.{name}: %(message)s')
+        syslog_handler.setFormatter(syslog_formatter)
+        logger.addHandler(syslog_handler)
+    except Exception:
+        pass  # Silently fail if syslog unavailable
+    
+    return logger
+
+
+def set_confdb_data(config_values, logger=None, update_files=True):
+    """
+    Set confdb data by replacing placeholders and writing to confdb.
+    Uses snapctl which requires hook/service context.
+    
+    Args:
+        config_values: Dictionary mapping config keys to their values
+                      (e.g., {"rob-cos-ip": "192.168.1.100", ...})
+        logger: Optional logger instance
+        update_files: If True, also run search_and_replace.sh to update files
+        
+    Returns:
+        Tuple of (success: bool, message: str)
+    """
+    if logger is None:
+        logger = setup_logger()
+    
+    # Validate that all required configuration values are provided
+    missing_values = [key for key in CONFIG_MAPPINGS.keys() if not config_values.get(key)]
+    
+    if missing_values:
+        msg = f"Configuration incomplete. Missing values: {', '.join(missing_values)}"
+        logger.info(msg)
+        return False, msg
+    
+    logger.info("All configuration values present, updating confdb")
+    
+    try:
+        # Path to the default configuration file
+        defaults_file = os.path.join(
+            os.environ.get("SNAP", ""),
+            "etc/configuration/defaults/device.yaml"
+        )
+        
+        # Read default YAML file
+        with open(defaults_file, 'r') as f:
+            config_data = f.read()
+        
+        # Replace all placeholders with real values
+        for config_key, placeholder in CONFIG_MAPPINGS.items():
+            if config_key in config_values and config_values[config_key]:
+                config_data = config_data.replace(placeholder, config_values[config_key])
+        
+        # Use snapctl set --view (requires hook/service context)
+        result = subprocess.run(
+            ["snapctl", "set", "--view", ":cos-registration-agent-control-configuration", f"data={config_data}"],
+            capture_output=True,
+            text=True
+        )
+        
+        if result.returncode != 0:
+            err_msg = f"Failed to write to confdb: {result.stderr}"
+            logger.warning(err_msg)
+            return False, err_msg
+        else:
+            logger.info("Configuration updated in confdb")
+        
+        # Update file-based configuration for content slot consumers
+        if update_files:
+            search_replace_script = os.path.join(
+                os.environ.get("SNAP", ""),
+                "usr/bin/search_and_replace.sh"
+            )
+            
+            result = subprocess.run(
+                [search_replace_script],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                err_msg = f"Failed to update configuration files: {result.stderr}"
+                logger.warning(err_msg)
+                return False, err_msg
+            else:
+                logger.info("Configuration files updated")
+        
+        return True, "Configuration updated successfully"
+        
+    except Exception as e:
+        err_msg = f"Error updating configuration: {e}"
+        logger.error(err_msg)
+        return False, err_msg
+
+
+def get_snap_config_values():
+    """
+    Get current snap configuration values from snapctl.
+    
+    Returns:
+        Dictionary mapping config keys to their current values
+    """
+    config_values = {}
+    
+    for config_key in CONFIG_MAPPINGS.keys():
+        try:
+            result = subprocess.run(
+                ["snapctl", "get", config_key],
+                capture_output=True,
+                text=True,
+                check=False
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                config_values[config_key] = result.stdout.strip()
+            else:
+                config_values[config_key] = None
+        except Exception:
+            config_values[config_key] = None
+    
+    return config_values

--- a/snap/local/init_confdb_service.py
+++ b/snap/local/init_confdb_service.py
@@ -1,48 +1,29 @@
 #!/usr/bin/env python3
+"""
+Confdb initialization service - one-shot.
+Checks snap config and writes to confdb once, then disables itself.
+Started by hooks when interface connects.
+"""
 
 import os
 import subprocess
 import sys
-import logging.handlers
 import time
+import logging.handlers
 
-# Setup logging to journald
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+# Add snap lib to Python path
+snap_dir = os.environ.get("SNAP", "")
+if snap_dir:
+    sys.path.insert(0, os.path.join(snap_dir, "usr/lib"))
 
-try:
-    handler = logging.handlers.SysLogHandler(address='/dev/log')
-    handler.setFormatter(logging.Formatter('rob-cos-demo-configuration.init-confdb-service: %(message)s'))
-    logger.addHandler(handler)
-except Exception:
-    pass
+from configure_logic import CONFIG_MAPPINGS, get_snap_config_values, setup_logger
 
-# Configuration mapping: snap config key -> placeholder name
-CONFIG_MAPPINGS = {
-    "rob-cos-ip": "rob-cos-ip-placeholder",
-    "model-name": "model-name-placeholder",
-    "robot-uid": "robot-uid-placeholder",
-}
-
-
-def get_snap_config(key):
-    """Get snap configuration value."""
-    try:
-        result = subprocess.run(
-            ["snapctl", "get", key],
-            capture_output=True,
-            text=True,
-            check=False
-        )
-        if result.returncode == 0 and result.stdout.strip():
-            return result.stdout.strip()
-    except Exception:
-        pass
-    return None
+# Setup logging
+logger = setup_logger("init-confdb-service")
 
 
 def stop_service():
-    """Stop this service."""
+    """Stop and disable this service."""
     try:
         subprocess.run(
             ["snapctl", "stop", "--disable", "rob-cos-demo-configuration.init-confdb"],
@@ -55,10 +36,14 @@ def stop_service():
 
 
 def write_config_to_confdb(config_values):
-    """Write configuration with real values to confdb.
+    """
+    Write configuration with real values to confdb.
     
     Args:
         config_values: Dictionary mapping config keys to their values
+        
+    Returns:
+        True if successful, False otherwise
     """
     defaults_file = os.path.join(
         os.environ.get("SNAP", ""),
@@ -86,6 +71,23 @@ def write_config_to_confdb(config_values):
             return False
         else:
             logger.info("Successfully wrote configuration to confdb")
+            
+            # Also update file-based configuration for content slot
+            search_replace_script = os.path.join(
+                os.environ.get("SNAP", ""),
+                "usr/bin/search_and_replace.sh"
+            )
+            
+            result = subprocess.run(
+                [search_replace_script],
+                capture_output=True,
+                text=True
+            )
+            if result.returncode != 0:
+                logger.warning(f"Failed to update configuration files: {result.stderr}")
+            else:
+                logger.info("Configuration files updated")
+            
             return True
     except Exception as e:
         logger.error(f"Error writing to confdb: {e}")
@@ -93,13 +95,11 @@ def write_config_to_confdb(config_values):
 
 
 def main():
-    """Main service loop."""
+    """Main service - one-shot execution."""
     logger.info("Confdb initialization service started")
     
     # Get all snap configuration values
-    config_values = {}
-    for config_key in CONFIG_MAPPINGS.keys():
-        config_values[config_key] = get_snap_config(config_key)
+    config_values = get_snap_config_values()
     
     # Check if all required values are set
     missing_values = [key for key, value in config_values.items() if not value]

--- a/snap/local/web_config/templates/index.html
+++ b/snap/local/web_config/templates/index.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>COS for Devices - Configuration</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }
+        
+        .container {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 10px 40px rgba(0, 0, 0, 0.2);
+            max-width: 600px;
+            width: 100%;
+            padding: 40px;
+        }
+        
+        h1 {
+            color: #333;
+            margin-bottom: 10px;
+            font-size: 28px;
+        }
+        
+        .subtitle {
+            color: #666;
+            margin-bottom: 30px;
+            font-size: 14px;
+        }
+        
+        .form-group {
+            margin-bottom: 25px;
+        }
+        
+        label {
+            display: block;
+            color: #333;
+            font-weight: 600;
+            margin-bottom: 8px;
+            font-size: 14px;
+        }
+        
+        input[type="text"] {
+            width: 100%;
+            padding: 12px 15px;
+            border: 2px solid #e0e0e0;
+            border-radius: 8px;
+            font-size: 15px;
+            transition: border-color 0.3s;
+        }
+        
+        input[type="text"]:focus {
+            outline: none;
+            border-color: #667eea;
+        }
+        
+        .button-group {
+            display: flex;
+            gap: 10px;
+            margin-top: 30px;
+        }
+        
+        button {
+            flex: 1;
+            padding: 14px 24px;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+        
+        .btn-primary {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        
+        .btn-primary:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
+        }
+        
+        .btn-primary:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+        }
+        
+        .btn-secondary {
+            background: #f5f5f5;
+            color: #666;
+        }
+        
+        .btn-secondary:hover {
+            background: #e0e0e0;
+        }
+        
+        .alert {
+            padding: 15px 20px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            font-size: 14px;
+            display: none;
+        }
+        
+        .alert-success {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        
+        .alert-error {
+            background: #f8d7da;
+            color: #721c24;
+            border: 1px solid #f5c6cb;
+        }
+        
+        .alert-info {
+            background: #d1ecf1;
+            color: #0c5460;
+            border: 1px solid #bee5eb;
+        }
+        
+        .loading {
+            display: inline-block;
+            width: 14px;
+            height: 14px;
+            border: 2px solid rgba(255, 255, 255, 0.3);
+            border-top: 2px solid white;
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            margin-left: 8px;
+        }
+        
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        
+        .status-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            margin-left: 10px;
+        }
+        
+        .status-configured {
+            background: #d4edda;
+            color: #155724;
+        }
+        
+        .status-unconfigured {
+            background: #fff3cd;
+            color: #856404;
+        }
+        
+        @media (max-width: 600px) {
+            .container {
+                padding: 30px 20px;
+            }
+            
+            h1 {
+                font-size: 24px;
+            }
+            
+            .button-group {
+                flex-direction: column;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>COS for Devices - Configuration</h1>
+        <p class="subtitle">Configure your COS for Devices settings</p>
+        
+        <div id="alert" class="alert"></div>
+        
+        <form id="configForm">
+            {% for key, field in fields.items() %}
+            <div class="form-group">
+                <label for="{{ key }}">
+                    {{ field.label }}
+                    {% if field.required %}<span style="color: #e74c3c;">*</span>{% endif %}
+                </label>
+                <input 
+                    type="{{ field.type }}" 
+                    id="{{ key }}" 
+                    name="{{ key }}" 
+                    placeholder="{{ field.placeholder }}"
+                    {% if field.required %}required{% endif %}
+                >
+            </div>
+            {% endfor %}
+            
+            <div class="button-group">
+                <button type="button" class="btn-secondary" onclick="loadConfig()">
+                    Reload Current Values
+                </button>
+                <button type="submit" class="btn-primary" id="submitBtn">
+                    Save Configuration
+                </button>
+            </div>
+        </form>
+    </div>
+    
+    <script>
+        // Load current configuration on page load
+        window.addEventListener('DOMContentLoaded', () => {
+            loadConfig();
+        });
+        
+        function showAlert(message, type) {
+            const alert = document.getElementById('alert');
+            alert.textContent = message;
+            alert.className = 'alert alert-' + type;
+            alert.style.display = 'block';
+            
+            setTimeout(() => {
+                alert.style.display = 'none';
+            }, 5000);
+        }
+        
+        function setLoading(loading) {
+            const submitBtn = document.getElementById('submitBtn');
+            if (loading) {
+                submitBtn.disabled = true;
+                submitBtn.innerHTML = 'Saving...<span class="loading"></span>';
+            } else {
+                submitBtn.disabled = false;
+                submitBtn.innerHTML = 'Save Configuration';
+            }
+        }
+        
+        async function loadConfig() {
+            try {
+                const response = await fetch('/api/config');
+                const config = await response.json();
+                
+                let allConfigured = true;
+                for (const [key, value] of Object.entries(config)) {
+                    const input = document.getElementById(key);
+                    if (input) {
+                        input.value = value || '';
+                        if (!value) {
+                            allConfigured = false;
+                        }
+                    }
+                }
+                
+                if (allConfigured) {
+                    showAlert('Current configuration loaded successfully', 'success');
+                } else {
+                    showAlert('Please configure all required fields', 'info');
+                }
+            } catch (error) {
+                showAlert('Failed to load configuration: ' + error.message, 'error');
+            }
+        }
+        
+        document.getElementById('configForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            
+            const formData = new FormData(e.target);
+            const config = Object.fromEntries(formData.entries());
+            
+            setLoading(true);
+            
+            try {
+                const response = await fetch('/api/config', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(config)
+                });
+                
+                const result = await response.json();
+                
+                if (result.success) {
+                    showAlert('Configuration saved successfully! The init-confdb service will now write to confdb.', 'success');
+                } else {
+                    showAlert('Error: ' + (result.errors ? result.errors.join(', ') : result.message), 'error');
+                }
+            } catch (error) {
+                showAlert('Failed to save configuration: ' + error.message, 'error');
+            } finally {
+                setLoading(false);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/snap/local/web_config_daemon.py
+++ b/snap/local/web_config_daemon.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Web configuration daemon - self-contained.
+Provides web UI for configuration and handles sync while running.
+User-controlled daemon (optional).
+"""
+
+import os
+import subprocess
+import sys
+import time
+import logging.handlers
+import threading
+import socket
+from flask import Flask, render_template, request, jsonify
+
+# Add snap lib to Python path
+snap_dir = os.environ.get("SNAP", "")
+if snap_dir:
+    sys.path.insert(0, os.path.join(snap_dir, "usr/lib"))
+
+from configure_logic import CONFIG_MAPPINGS, set_confdb_data, get_snap_config_values, setup_logger
+
+# Setup logging
+logger = setup_logger("web-config-daemon")
+
+# State file to track last known config values (separate from background daemon)
+STATE_FILE = os.path.join(
+    os.environ.get("SNAP_DATA", "/tmp"),
+    "web-config-state.txt"
+)
+
+# Flask app for web UI
+app = Flask(__name__, 
+            template_folder=os.path.join(snap_dir, "usr/share/web_config/templates") if snap_dir else "templates",
+            static_folder=os.path.join(snap_dir, "usr/share/web_config/static") if snap_dir else "static")
+
+# Configuration fields for web UI
+CONFIG_FIELDS = {
+    "rob-cos-ip": {
+        "label": "COS Server IP Address",
+        "placeholder": "e.g., 192.168.1.100",
+        "type": "text",
+        "required": True
+    },
+    "model-name": {
+        "label": "Model Name",
+        "placeholder": "e.g., cos-robotics-model",
+        "type": "text",
+        "required": True
+    },
+    "robot-uid": {
+        "label": "Robot UID",
+        "placeholder": "e.g., robot-12345",
+        "type": "text",
+        "required": True
+    }
+}
+
+
+def get_snap_config(key):
+    """Get snap configuration value."""
+    try:
+        result = subprocess.run(
+            ["snapctl", "get", key],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return ""
+
+
+def set_snap_config(key, value):
+    """Set snap configuration value using snapctl."""
+    try:
+        result = subprocess.run(
+            ["snapctl", "set", f"{key}={value}"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return True, "Success"
+    except subprocess.CalledProcessError as e:
+        return False, f"Failed to set {key}: {e.stderr}"
+    except Exception as e:
+        return False, str(e)
+
+
+@app.route('/')
+def index():
+    """Render the configuration page."""
+    return render_template('index.html', fields=CONFIG_FIELDS)
+
+
+@app.route('/api/config', methods=['GET'])
+def get_config():
+    """Get current configuration values."""
+    config = {}
+    for key in CONFIG_FIELDS.keys():
+        config[key] = get_snap_config(key)
+    return jsonify(config)
+
+
+@app.route('/api/config', methods=['POST'])
+def set_config():
+    """Set configuration values via snap config."""
+    data = request.json
+    errors = []
+    
+    # Validate all required fields are present
+    for key, field_info in CONFIG_FIELDS.items():
+        if field_info.get('required') and not data.get(key):
+            errors.append(f"{field_info['label']} is required")
+    
+    if errors:
+        return jsonify({"success": False, "errors": errors}), 400
+    
+    # Set each snap configuration value
+    for key in CONFIG_FIELDS.keys():
+        if key in data:
+            success, message = set_snap_config(key, data[key])
+            if not success:
+                errors.append(message)
+    
+    if errors:
+        return jsonify({"success": False, "errors": errors}), 500
+    
+    return jsonify({
+        "success": True, 
+        "message": "Configuration values set. Sync will update confdb shortly."
+    })
+
+
+def get_local_ip():
+    """Get the local IP address."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        local_ip = s.getsockname()[0]
+        s.close()
+        return local_ip
+    except Exception:
+        return "127.0.0.1"
+
+
+def load_last_state():
+    """Load the last known configuration state."""
+    if not os.path.exists(STATE_FILE):
+        return {}
+    
+    try:
+        state = {}
+        with open(STATE_FILE, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if '=' in line:
+                    key, value = line.split('=', 1)
+                    state[key] = value
+        return state
+    except Exception as e:
+        logger.warning(f"Failed to load state file: {e}")
+        return {}
+
+
+def save_state(config_values):
+    """Save current configuration state."""
+    try:
+        with open(STATE_FILE, 'w') as f:
+            for key, value in config_values.items():
+                if value:
+                    f.write(f"{key}={value}\n")
+    except Exception as e:
+        logger.warning(f"Failed to save state file: {e}")
+
+
+def config_changed(current_config, last_config):
+    """Check if configuration has changed."""
+    for key in CONFIG_MAPPINGS.keys():
+        if current_config.get(key) != last_config.get(key):
+            return True
+    return False
+
+
+def sync_loop():
+    """Configuration sync loop - runs while web UI is active."""
+    logger.info("Web config sync loop started")
+    
+    # Check interval in seconds
+    check_interval = 5
+    
+    last_config = load_last_state()
+    
+    while True:
+        try:
+            # Get current snap configuration values
+            current_config = get_snap_config_values()
+            
+            # Check if configuration has changed
+            if config_changed(current_config, last_config):
+                logger.info("Configuration change detected")
+                
+                # Check if all required values are present
+                all_set = all(current_config.get(key) for key in CONFIG_MAPPINGS.keys())
+                
+                if all_set:
+                    logger.info("All configuration values present, syncing to confdb")
+                    
+                    # Sync to confdb
+                    success, message = set_confdb_data(current_config, logger)
+                    
+                    if success:
+                        logger.info("Successfully synced configuration to confdb")
+                        # Update state only on success
+                        save_state(current_config)
+                        last_config = current_config
+                    else:
+                        logger.warning(f"Failed to sync to confdb: {message}")
+                else:
+                    # Some values are missing - clear the state
+                    logger.info("Configuration incomplete, clearing state")
+                    save_state({})
+                    last_config = {}
+            
+            # Sleep before next check
+            time.sleep(check_interval)
+            
+        except Exception as e:
+            logger.error(f"Error in sync loop: {e}")
+            time.sleep(check_interval)
+
+
+def main():
+    """Main entry point - start both web server and sync loop."""
+    logger.info("Web configuration daemon starting")
+    
+    # Start sync loop in background thread
+    sync_thread = threading.Thread(target=sync_loop, daemon=True)
+    sync_thread.start()
+    logger.info("Sync loop thread started")
+    
+    # Start web server in main thread
+    port = 8080
+    host = '0.0.0.0'
+    local_ip = get_local_ip()
+    
+    logger.info(f"Web UI starting on http://{local_ip}:{port}")
+    print("=" * 60)
+    print("COS for Devices - Configuration Web UI")
+    print("=" * 60)
+    print(f"\nOpen the following URL in your browser:")
+    print(f"\n  http://{local_ip}:{port}")
+    print(f"\n  (or http://localhost:{port} from this machine)")
+    print("\nPress Ctrl+C to stop")
+    print("=" * 60 + "\n")
+    
+    # Run Flask app (blocks until stopped)
+    app.run(host=host, port=port, debug=False)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        logger.info("Web configuration daemon stopped")
+        sys.exit(0)
+    except Exception as e:
+        logger.error(f"Unexpected error: {e}")
+        sys.exit(1)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,12 +39,36 @@ slots:
       - $SNAP_COMMON/configuration
 
 parts:
+  flask-deps:
+    plugin: python
+    source: .
+    python-packages:
+      - Flask==3.0.0
+      - Werkzeug==3.0.1
+    stage-packages:
+      - python3-pip
+  
   scripts:
     plugin: dump
     source: snap/local/
     organize:
       '*.sh': usr/bin/
-      '*.py': usr/bin/
+      'init_confdb_service.py': usr/bin/
+      'web_config_daemon.py': usr/bin/
+      'configure_logic.py': usr/lib/
+    stage:
+      - usr/bin/*.sh
+      - usr/bin/init_confdb_service.py
+      - usr/bin/web_config_daemon.py
+      - usr/lib/configure_logic.py
+    after: [flask-deps]
+  
+  web-config:
+    plugin: dump
+    source: snap/local/web_config/
+    organize:
+      '*': usr/share/web_config/
+  
   configuration:
     plugin: dump
     source: snap/local/configuration/
@@ -63,3 +87,12 @@ apps:
     daemon: simple
     install-mode: disable
     plugs: [cos-registration-agent-control-configuration]
+  
+  web-config:
+    command: usr/bin/web_config_daemon.py
+    daemon: simple
+    install-mode: disable
+    plugs: 
+      - network
+      - network-bind
+      - cos-registration-agent-control-configuration


### PR DESCRIPTION
Added a responsive web UI for configuring snap settings:
- Flask app with REST API for reading/writing snap config
- Responsive HTML/CSS interface (no frameworks, jQuery-free)
- GET/POST endpoints for configuration management
- Calls snapctl set behind the scenes
- Displays current values on load
- Form validation and error handling

Usage:
snap start rob-cos-demo-configuration.web-config

