### PR TITLE
feat(ros2-exporter-agent): migrate to the new parameter system

### DIFF
--- a/snap/local/configuration/ros2-data-exporter.yaml
+++ b/snap/local/configuration/ros2-data-exporter.yaml
@@ -1,8 +1,0 @@
-uid: robot-uid-placeholder # the robot uid
-remote-server-ip: rob-cos-ip-placeholder # address of the server to store data
-remote-server-port: 2222 # port of the server to send data
-max-bag-size: 250000000 # 250M maximum bag file size before we split into another file
-max-bag-duration: 300 # 5min maximum bag duration before we split into another file
-storage-base-path: "/var/lib/caddy-fileserver/" # storage base path on the server where we want to store our data (robot uid will be added by the snap)
-topic-regex: ".*" # topic regex to include topics to the record
-topic-exclude: "/rosout" # topic regex to exclude topics from the record

--- a/snap/local/configuration/ros2-exporter-agent/rclone.conf
+++ b/snap/local/configuration/ros2-exporter-agent/rclone.conf
@@ -1,0 +1,9 @@
+[fileserver]
+type = sftp
+host = rob-cos-ip-placeholder
+user = root
+port = 2222
+key_file = /root/snap/ros2-exporter-agent/common/device_rsa_key
+[bagstore]
+type = alias
+remote = fileserver:/var/lib/caddy-fileserver/robot-uid-placeholder

--- a/snap/local/configuration/ros2-exporter-agent/rosbag2-recorder.yaml
+++ b/snap/local/configuration/ros2-exporter-agent/rosbag2-recorder.yaml
@@ -1,0 +1,11 @@
+# For the full list of available ros__parameters you can refer to
+# https://github.com/ros2/rosbag2/blob/jazzy/rosbag2_transport/test/resources/recorder_node_params.yaml
+cos_rosbag2_recorder:
+  ros__parameters:
+    record:
+      regex: '.*'
+      exclude_topics: ["/rosout"] # topic regex to exclude topics from the record
+    storage:
+      storage_id: 'mcap'
+      max_bagfile_duration: 300 # 5min maximum bag duration before we split into another file
+      max_bagfile_size: 250000000 # 250M maximum bag file size before we split into another file


### PR DESCRIPTION
This pull request introduces new configuration files and updates existing ones to improve the configuration of the `ros2-exporter-agent`. The changes focus on moving configuration parameters from one file to two. One for the rclone configuration and the other for the rosbag_transport recorder.

`rclone.conf` configures an SFTP remote and an alias for bag storage, which will facilitate secure data transfer to the server. The configuration is now responsible for the synching protocole as well as the storage destination.

Matching with: https://github.com/canonical/ros2-exporter-agent/pull/31