### PR TITLE
Feat/s3 rclone

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-bash "${SNAP}/usr/bin/search_and_replace.sh"
+bash -e "${SNAP}/usr/bin/search_and_replace.sh"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,3 @@
 #!/bin/sh -e
 
-bash $SNAP/usr/bin/search_and_replace.sh
+bash "${SNAP}/usr/bin/search_and_replace.sh"

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
-cp -R $SNAP/etc/configuration/ $SNAP_COMMON/
+cp -R "${SNAP}/etc/configuration/" "${SNAP_COMMON}/"
 
-snapctl set rob-cos-base-url=$(cat $SNAP_COMMON/configuration/rob-cos-base-url)
+snapctl set rob-cos-base-url=$(cat "${SNAP_COMMON}/configuration/rob-cos-base-url")
 snapctl set device-uid=$(bash generate_device_uid.sh)
 snapctl set s3-access-key-id=$(cat "${SNAP_COMMON}/configuration/s3-access-key-id")
 snapctl set s3-secret-access-key=$(cat "${SNAP_COMMON}/configuration/s3-secret-access-key")

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,4 +4,6 @@ cp -R $SNAP/etc/configuration/ $SNAP_COMMON/
 
 snapctl set rob-cos-base-url=$(cat $SNAP_COMMON/configuration/rob-cos-base-url)
 snapctl set device-uid=$(bash generate_device_uid.sh)
+snapctl set s3-access-key-id=$(cat $SNAP_COMMON/configuration/s3-access-key-id)
+snapctl set s3-secret-access-key=$(cat $SNAP_COMMON/configuration/s3-secret-access-key)
 snapctl set configuration-url!

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,6 +4,6 @@ cp -R $SNAP/etc/configuration/ $SNAP_COMMON/
 
 snapctl set rob-cos-base-url=$(cat $SNAP_COMMON/configuration/rob-cos-base-url)
 snapctl set device-uid=$(bash generate_device_uid.sh)
-snapctl set s3-access-key-id=$(cat $SNAP_COMMON/configuration/s3-access-key-id)
-snapctl set s3-secret-access-key=$(cat $SNAP_COMMON/configuration/s3-secret-access-key)
+snapctl set s3-access-key-id=$(cat "${SNAP_COMMON}/configuration/s3-access-key-id")
+snapctl set s3-secret-access-key=$(cat "${SNAP_COMMON}/configuration/s3-secret-access-key")
 snapctl set configuration-url!

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,7 +3,7 @@
 cp -R "${SNAP}/etc/configuration/" "${SNAP_COMMON}/"
 
 snapctl set rob-cos-base-url=$(cat "${SNAP_COMMON}/configuration/rob-cos-base-url")
-snapctl set device-uid=$(bash generate_device_uid.sh)
+snapctl set device-uid=$(bash "${SNAP}/usr/bin/generate_device_uid.sh")
 snapctl set s3-access-key-id=$(cat "${SNAP_COMMON}/configuration/s3-access-key-id")
 snapctl set s3-secret-access-key=$(cat "${SNAP_COMMON}/configuration/s3-secret-access-key")
 snapctl set configuration-url!

--- a/snap/local/configuration/ros2-data-exporter.yaml
+++ b/snap/local/configuration/ros2-data-exporter.yaml
@@ -1,8 +1,0 @@
-uid: robot-uid-placeholder # the robot uid
-remote-server-ip: rob-cos-ip-placeholder # address of the server to store data
-remote-server-port: 2222 # port of the server to send data
-max-bag-size: 250000000 # 250M maximum bag file size before we split into another file
-max-bag-duration: 300 # 5min maximum bag duration before we split into another file
-storage-base-path: "/var/lib/caddy-fileserver/" # storage base path on the server where we want to store our data (robot uid will be added by the snap)
-topic-regex: ".*" # topic regex to include topics to the record
-topic-exclude: "/rosout" # topic regex to exclude topics from the record

--- a/snap/local/configuration/ros2-exporter-agent/rclone.conf
+++ b/snap/local/configuration/ros2-exporter-agent/rclone.conf
@@ -4,7 +4,7 @@ provider = Ceph
 env_auth = false
 access_key_id = rob-cos-access-key-id-placeholder
 secret_access_key = rob-cos-secret-access-key-placeholder
-endpoint = rob-cos-ip-placeholder
+endpoint = http://rob-cos-ip-placeholder
 force_path_style = true
 [bagstore]
 type = alias

--- a/snap/local/configuration/ros2-exporter-agent/rclone.conf
+++ b/snap/local/configuration/ros2-exporter-agent/rclone.conf
@@ -1,0 +1,11 @@
+[s3microceph]
+type = s3
+provider = Ceph
+env_auth = false
+access_key_id = rob-cos-access-key-id-placeholder
+secret_access_key = rob-cos-secret-access-key-placeholder
+endpoint = rob-cos-ip-placeholder
+force_path_style = true
+[bagstore]
+type = alias
+remote = s3microceph:robot-uid-placeholder

--- a/snap/local/configuration/ros2-exporter-agent/rosbag2-recorder.yaml
+++ b/snap/local/configuration/ros2-exporter-agent/rosbag2-recorder.yaml
@@ -1,0 +1,11 @@
+# For the full list of available ros__parameters you can refer to
+# https://github.com/ros2/rosbag2/blob/jazzy/rosbag2_transport/test/resources/recorder_node_params.yaml
+cos_rosbag2_recorder:
+  ros__parameters:
+    record:
+      regex: '.*'
+      exclude_topics: ["/rosout"] # topic regex to exclude topics from the record
+    storage:
+      storage_id: 'mcap'
+      max_bagfile_duration: 300 # 5min maximum bag duration before we split into another file
+      max_bagfile_size: 250000000 # 250M maximum bag file size before we split into another file

--- a/snap/local/configuration/s3-access-key-id
+++ b/snap/local/configuration/s3-access-key-id
@@ -1,0 +1,1 @@
+rob-cos-access-key-id-placeholder

--- a/snap/local/configuration/s3-secret-access-key
+++ b/snap/local/configuration/s3-secret-access-key
@@ -1,0 +1,1 @@
+rob-cos-secret-access-key-placeholder

--- a/snap/local/search_and_replace.sh
+++ b/snap/local/search_and_replace.sh
@@ -45,7 +45,7 @@ fi
 
 CURRENT_COS_SERVER_URL=$(snapctl get rob-cos-base-url)
 CURRENT_COS_SERVER_IP=$(echo "$CURRENT_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)
-STORED_COS_SERVER_URL=$(cat "$SNAP_COMMON/configuration/rob-cos-base-url")
+STORED_COS_SERVER_URL=$(cat "${SNAP_COMMON}/configuration/rob-cos-base-url")
 STORED_COS_SERVER_IP="$(echo "$STORED_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)"
 
 if [ "$CURRENT_COS_SERVER_URL" != "$STORED_COS_SERVER_URL" ]; then

--- a/snap/local/search_and_replace.sh
+++ b/snap/local/search_and_replace.sh
@@ -28,7 +28,7 @@ if [ "$CURRENT_DEVICE_ID" != "$STORED_DEVICE_ID" ]; then
 fi
 
 CURRENT_S3_ACCESS_KEY_ID=$(snapctl get s3-access-key-id)
-STORED_S3_ACCESS_KEY_ID=$(cat $SNAP_COMMON/configuration/s3-access-key-id)
+STORED_S3_ACCESS_KEY_ID=$(cat "${SNAP_COMMON}/configuration/s3-access-key-id")
 
 if [ "$CURRENT_S3_ACCESS_KEY_ID" != "$STORED_S3_ACCESS_KEY_ID" ]; then
     echo "s3-access-key-id is different updating!"
@@ -36,9 +36,9 @@ if [ "$CURRENT_S3_ACCESS_KEY_ID" != "$STORED_S3_ACCESS_KEY_ID" ]; then
 fi
 
 CURRENT_S3_SECRET_ACCESS_KEY=$(snapctl get s3-secret-access-key)
-STORED_S3_SECRET_ACCESS_KEY=$(cat $SNAP_COMMON/configuration/s3-secret-access-key)
+STORED_S3_SECRET_ACCESS_KEY=$(cat "${SNAP_COMMON}/configuration/s3-secret-access-key")
 
-if [ -n "$CURRENT_S3_SECRET_ACCESS_KEY" ] && [ "$CURRENT_S3_SECRET_ACCESS_KEY" != "$STORED_S3_SECRET_ACCESS_KEY" ]; then
+if [ "$CURRENT_S3_SECRET_ACCESS_KEY" != "$STORED_S3_SECRET_ACCESS_KEY" ]; then
     echo "s3-secret-access-key is different updating!"
     search_and_replace "$STORED_S3_SECRET_ACCESS_KEY" "$CURRENT_S3_SECRET_ACCESS_KEY"
 fi

--- a/snap/local/search_and_replace.sh
+++ b/snap/local/search_and_replace.sh
@@ -20,20 +20,36 @@ search_and_replace() {
 }
 
 CURRENT_DEVICE_ID=$(snapctl get device-uid)
-STORED_DEVICE_ID=$(cat $SNAP_COMMON/configuration/uid)
+STORED_DEVICE_ID=$(cat "${SNAP_COMMON}/configuration/uid")
 
 if [ "$CURRENT_DEVICE_ID" != "$STORED_DEVICE_ID" ]; then
     echo "device_id is different updating!"
-    search_and_replace $STORED_DEVICE_ID $CURRENT_DEVICE_ID
+    search_and_replace "$STORED_DEVICE_ID" "$CURRENT_DEVICE_ID"
+fi
+
+CURRENT_S3_ACCESS_KEY_ID=$(snapctl get s3-access-key-id)
+STORED_S3_ACCESS_KEY_ID=$(cat $SNAP_COMMON/configuration/s3-access-key-id)
+
+if [ "$CURRENT_S3_ACCESS_KEY_ID" != "$STORED_S3_ACCESS_KEY_ID" ]; then
+    echo "s3-access-key-id is different updating!"
+    search_and_replace "$STORED_S3_ACCESS_KEY_ID" "$CURRENT_S3_ACCESS_KEY_ID"
+fi
+
+CURRENT_S3_SECRET_ACCESS_KEY=$(snapctl get s3-secret-access-key)
+STORED_S3_SECRET_ACCESS_KEY=$(cat $SNAP_COMMON/configuration/s3-secret-access-key)
+
+if [ -n "$CURRENT_S3_SECRET_ACCESS_KEY" ] && [ "$CURRENT_S3_SECRET_ACCESS_KEY" != "$STORED_S3_SECRET_ACCESS_KEY" ]; then
+    echo "s3-secret-access-key is different updating!"
+    search_and_replace "$STORED_S3_SECRET_ACCESS_KEY" "$CURRENT_S3_SECRET_ACCESS_KEY"
 fi
 
 CURRENT_COS_SERVER_URL=$(snapctl get rob-cos-base-url)
 CURRENT_COS_SERVER_IP=$(echo "$CURRENT_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)
-STORED_COS_SERVER_URL=$(cat $SNAP_COMMON/configuration/rob-cos-base-url)
+STORED_COS_SERVER_URL=$(cat "$SNAP_COMMON/configuration/rob-cos-base-url")
 STORED_COS_SERVER_IP="$(echo "$STORED_COS_SERVER_URL" | awk -F '//' '{print $2}' | cut -d '/' -f 1)"
 
 if [ "$CURRENT_COS_SERVER_URL" != "$STORED_COS_SERVER_URL" ]; then
     echo "rob-cos-base-url is different updating!"
-    search_and_replace $STORED_COS_SERVER_URL $CURRENT_COS_SERVER_URL
-    search_and_replace $STORED_COS_SERVER_IP $CURRENT_COS_SERVER_IP
+    search_and_replace "$STORED_COS_SERVER_URL" "$CURRENT_COS_SERVER_URL"
+    search_and_replace "$STORED_COS_SERVER_IP" "$CURRENT_COS_SERVER_IP"
 fi


### PR DESCRIPTION
This pull request updates the snap configuration to add S3 credentials, and introduces new configuration files for the ROS2 data exporter. The main focus is on ensuring that S3 credentials are correctly propagated and updated throughout the snap environment, as well as enhancing the configuration flexibility for ROS2 data export and recording.

**Credential and Configuration Handling Improvements:**

* The `snap/hooks/install` and `snap/hooks/configure` scripts now use safer variable expansions and ensure that S3 credentials (`s3-access-key-id` and `s3-secret-access-key`) are set from configuration files during installation.
* The `snap/local/search_and_replace.sh` script is enhanced to detect and update changes to the S3 access key ID, and S3 secret access key, ensuring all relevant configuration files are updated if credentials change.

These changes collectively make the snap more robust and flexible in handling device identity and S3 credentials, and better support ROS2 data export and recording.

This has been testing with a microceph deployment and this PR: https://github.com/canonical/rob-cos-demo-configuration/pull/39