### PR TITLE
Feat/rclone confdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ More information on how to write a configuration snap for cos for device can be 
 
 ## Installation
 
+First, make sure you've enable the confdb experimental feature.
+
+```
+sudo snap set system experimental.confdb=true
+```
+
 To install the basic setup:
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ More information on how to write a configuration snap for cos for device can be 
 
 ## Installation
 
-First, make sure you've enable the confdb experimental feature.
+First, make sure you've enabled the confdb experimental feature.
 
 ```
 sudo snap set system experimental.confdb=true

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,3 +1,10 @@
 #!/bin/sh -e
 
 bash "${SNAP}/usr/bin/search_and_replace.sh"
+
+if snapctl is-connected ros2-exporter-agent-configuration; then
+  logger -t "${SNAP_NAME}" "Plug 'ros2-exporter-agent-configuration' is connected"
+  "${SNAP}/usr/bin/ros2-exporter-agent-configuration.sh"
+else
+  logger -t "${SNAP_NAME}" "Plug 'ros2-exporter-agent-configuration' is not connected"
+fi

--- a/snap/hooks/connect-plug-ros2-exporter-agent-configuration
+++ b/snap/hooks/connect-plug-ros2-exporter-agent-configuration
@@ -1,3 +1,3 @@
 #!/bin/sh -eu
 
-bash "${SNAP}/usr/bin/ros2-exporter-agent-configuration.sh"
+"${SNAP}/usr/bin/ros2-exporter-agent-configuration.sh"

--- a/snap/hooks/connect-plug-ros2-exporter-agent-configuration
+++ b/snap/hooks/connect-plug-ros2-exporter-agent-configuration
@@ -1,0 +1,3 @@
+#!/bin/sh -eu
+
+bash "${SNAP}/usr/bin/ros2-exporter-agent-configuration.sh"

--- a/snap/local/ros2-exporter-agent-configuration.sh
+++ b/snap/local/ros2-exporter-agent-configuration.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -eu
+
+logger -t "${SNAP_NAME}" "Updating the ros2-exporter-agent configuration-file"
+snapctl set --view :ros2-exporter-agent-configuration rclone="$(cat "${SNAP_COMMON}/configuration/ros2-exporter-agent/rclone.conf")"
+snapctl set --view :ros2-exporter-agent-configuration rosbag2-recorder="$(cat "${SNAP_COMMON}/configuration/ros2-exporter-agent/rosbag2-recorder.yaml")"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,14 @@ slots:
     interface: content
     read: 
       - $SNAP_COMMON/configuration
+plugs:
+  ros2-exporter-agent-configuration:
+    interface: confdb
+    account: canonical-robotics
+    view: ros2-exporter-agent/configuration
+hooks:
+  configure:
+    plugs: [ros2-exporter-agent-configuration]
 
 parts:
   scripts:


### PR DESCRIPTION
Configure the ros2-exporter-agent over confdb.

Tested with the micoceph s3 endpoint.

Works together with: https://github.com/canonical/ros2-exporter-agent/pull/32